### PR TITLE
Update org.gnome.Platform to 41

### DIFF
--- a/com.bitstower.Markets.json
+++ b/com.bitstower.Markets.json
@@ -24,25 +24,6 @@
     ],
     "modules" : [
         {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dprofiling=false",
-                "-Dintrospection=enabled",
-                "-Dgtk_doc=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.0.3"
-                }
-            ]
-        },
-        {
             "name" : "bitstower-markets",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/com.bitstower.Markets.json
+++ b/com.bitstower.Markets.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.bitstower.Markets",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "command" : "bitstower-markets",
     "finish-args" : [


### PR DESCRIPTION
Update `org.gnome.Platform` to latest and greatest runtime v41. And drop `libhandy` module. Now it's part of new GNOME runtime.

