### PR TITLE
build: Add finish-args: device=dri

### DIFF
--- a/com.bitstower.Markets.json
+++ b/com.bitstower.Markets.json
@@ -5,6 +5,7 @@
     "sdk" : "org.gnome.Sdk",
     "command" : "bitstower-markets",
     "finish-args" : [
+        "--device=dri",
         "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",


### PR DESCRIPTION
For OpenGL rendering. According to talks with other maintainers this will not hurt and should been added to all gtk apps. Only if there some serious reasons to no adding it. Thanks in advance.